### PR TITLE
Created main.yml file to setup GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI on Push and Pull Request
+
+on: [push, pull_request]
+
+jobs:     
+  Android:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Android
+      run: |
+        cd src
+        nuget restore
+        cd Xamarin.Netflix/Xamarin.Netflix.Android
+        msbuild Blank.Android.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
+        
+  iOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: iOS
+      run: |
+        cd src
+        nuget restore
+        msbuild Xamarin.Netflix/Xamarin.Netflix.iOS/Xamarin.Netflix.iOS.csproj /verbosity:normal /t:Rebuild /p:Platform=iPhoneSimulator /p:Configuration=Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         cd src
         nuget restore
         cd Xamarin.Netflix/Xamarin.Netflix.Android
-        msbuild Blank.Android.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
+        msbuild Xamarin.Netflix.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
         
   iOS:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         cd src
         nuget restore
         cd Xamarin.Netflix/Xamarin.Netflix.Android
-        msbuild Xamarin.Netflix.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
+        msbuild Xamarin.Netflix.Android.csproj /verbosity:normal /t:Rebuild /p:Configuration=Debug
         
   iOS:
     runs-on: macos-latest

--- a/src/Xamarin.Netflix/Xamarin.Netflix.Android/Xamarin.Netflix.Android.csproj
+++ b/src/Xamarin.Netflix/Xamarin.Netflix.Android/Xamarin.Netflix.Android.csproj
@@ -35,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
* Added main.yml file that orders 2 jobs on every push and merge request
* One job is to build iOS and the other builds Android
* Removed armeabi from the list of Android ABI's since it was also breaking the Android build

**Purpose of Action**
-----
* The action performs a sanity test on your apps— makes sure the iOS & Android apps build on each commit or merge request, ensuring that there is no bug introduced in that commit
* More details in [the article](https://medium.com/@prototypemakers/using-github-actions-with-ios-and-android-xamarin-apps-693a93b48a61) or the corresponding [unmetered article link](https://medium.com/@prototypemakers/using-github-actions-with-ios-and-android-xamarin-apps-693a93b48a61?sk=cd81773f2e5a5931ae49c9362b4db795)

**Testing**
--------
* Tested the Action on [my fork](https://github.com/saamerm/xamarin-forms-netflix-sample/commit/5c33f6cc7d32fce2dcd7b5930c6b9a42b65f75c6/checks?check_suite_id=396834221) and it passed the tests 